### PR TITLE
Mini gas optimization for sale minting

### DIFF
--- a/contracts/Tubbies.sol
+++ b/contracts/Tubbies.sol
@@ -122,10 +122,12 @@ contract Tubbies is ERC721, MultisigOwnable, VRFConsumerBase {
         }
         require(msg.value == cost, "wrong payment");
         unchecked {
+            uint currentTotal = totalMinted;
             for(uint i = 0; i<tubbiesToMint; i++){
-                _mint(msg.sender, totalMinted);
-                totalMinted++; // OPTIMIZE: Use memory variable?
+                _mint(msg.sender, currentTotal);
+                currentTotal++;
             }
+            totalMinted = currentTotal;
         }
         require(totalMinted <= TOKEN_LIMIT, "limit reached");
     }


### PR DESCRIPTION
> context: came here from the randomizing nfts article and was reading over the contract

Load `totalMinted` out of storage and put it in memory for cheaper access. This saves ~1% of gas per the gas estimator:
```
> npx hardhat test
before  mintFromSale            ·      156150  ·     190350  ·     156264
after   mintFromSale            ·      154787  ·     188987  ·     154901
```

code golfing around to see if there are other savings :) happy to help out in other ways too if needed!