### PR TITLE
mint gas golfing

### DIFF
--- a/contracts/Tubbies.sol
+++ b/contracts/Tubbies.sol
@@ -106,11 +106,13 @@ contract Tubbies is ERC721, MultisigOwnable, VRFConsumerBase {
         require(claimed[msg.sender] == false, "already claimed");
         claimed[msg.sender] = true;
         require(msg.value == 0.1 ether, "wrong payment");
-        _mint(msg.sender, totalMinted);
+        uint total = totalMinted;
+        _mint(msg.sender, total);
         unchecked {
-            totalMinted++; // Can't overflow
+            total++; // Can't overflow
         }
-        require(totalMinted <= TOKEN_LIMIT, "limit reached");
+        require(total <= TOKEN_LIMIT, "limit reached");
+        totalMinted = total;
     }
 
     function mintFromSale(uint tubbiesToMint) public payable {


### PR DESCRIPTION
Avoid multiple SLOADs by reading var from mem.

Gas report before:
```
|  Tubbies                   ·  mint                    ·           -  ·          -  ·     114921  ·            1  ·          -  │
```
and after:
```
|  Tubbies                   ·  mint                    ·           -  ·          -  ·     114730  ·            1  ·          -  │
```